### PR TITLE
Improve/fix querySelector usage

### DIFF
--- a/content.js
+++ b/content.js
@@ -5,23 +5,23 @@
 var makeReadable = function() {
 	// Un-position:fixed the top nav bar
 	var topNav = document.querySelector('.metabar.u-fixed');
-	if (topNav != null) {
+	if (topNav) {
 		topNav.classList.remove('u-fixed');
 	}
 	// Remove the footer
 	var getUpdatesBar = document.querySelector('.js-stickyFooter');
-	if (getUpdatesBar != null) {
+	if (getUpdatesBar) {
 		getUpdatesBar.style.display = 'none';
 	}
 };
 
 var hideDickbar = function() {
 	var dickbar = document.querySelector('.js-postShareWidget');
-	if (dickbar != null) {
+	if (dickbar) {
 		dickbar.style.display = 'none';
 	}
 	var footerDickbar = document.querySelector('footer > .container:first-child');
-	if (footerDickbar != null) {
+	if (footerDickbar) {
 		footerDickbar.style.display = 'none';
 	}
 };
@@ -29,14 +29,14 @@ var hideDickbar = function() {
 var disableLazyLoading = function() {
 	// Get all <noscript> tags accompanying dynamically-loading <img>s
 	var hiddenMedia = document.querySelectorAll('noscript.js-progressiveMedia-inner');
-	if (hiddenMedia == null) {
+	if (hiddenMedia.length === 0) {
 		return;
 	}
 	for (var i=0; i<hiddenMedia.length; i++) {
 		// Create new <img> element from the one in <noscript> and add it in.
 		// This is certainly a roundabout way of doing things, but I didn't want to
 		// spend more time reverse-engineering Medium's lazy-loading code.
-		var img = document.createElement('img');
+		var img = new Image();
 		var srcMatch = hiddenMedia[i].textContent.match(/src="(https:\/\/[^"]+)"/);
 		if (srcMatch != null) {
 			img.src = srcMatch[1];
@@ -48,7 +48,7 @@ var disableLazyLoading = function() {
 
 var shrinkHeaderImages = function() {
 	var ridiculousHeaderImage = document.querySelector('figure.graf--layoutFillWidth');
-	if (ridiculousHeaderImage != null) {
+	if (ridiculousHeaderImage) {
 		ridiculousHeaderImage.style.maxWidth = '700px';
 		ridiculousHeaderImage.style.margin = '0 auto';
 	}
@@ -64,9 +64,7 @@ var observer = new MutationObserver(function(mutations){
 var config = {attributes: true};
 
 // Only run this on Medium sites. 
-// Ensure that by checking for <meta property="al:ios:app_name" content="Medium"> in the document <head />
-var metaCheck = document.head.querySelector('meta[property="al:ios:app_name"]');
-if (metaCheck != null && metaCheck.content == "Medium") {
+if (document.querySelector('head meta[property="al:ios:app_name"][content="medium"]')) {
 	makeReadable();
 	shrinkHeaderImages();
 
@@ -79,5 +77,5 @@ if (metaCheck != null && metaCheck.content == "Medium") {
 		}
 	});
 
-	observer.observe(document.querySelector('body'), config);
+	observer.observe(document.body, config);
 }


### PR DESCRIPTION
- `!= null` is implied
- `querySelectorAll` always returns an `NodeList`, never a `null`
- `new Image()` is the shortest way to create an `<img>`
- `querySelector` can check the content of an attribute
- `document.body` is shorter than `querySelector`