### PR TITLE
Update manifest permissions to match medium url

### DIFF
--- a/content.js
+++ b/content.js
@@ -58,24 +58,21 @@ var observer = new MutationObserver(function(mutations){
 	mutations.forEach(function(){
 		makeReadable();
 		shrinkHeaderImages();
-	});	
+	});
 });
 
 var config = {attributes: true};
 
-// Only run this on Medium sites. 
-if (document.querySelector('head meta[property="al:ios:app_name"][content="medium"]')) {
-	makeReadable();
-	shrinkHeaderImages();
+makeReadable();
+shrinkHeaderImages();
 
-	chrome.storage.sync.get(null, function(items) {
-		if (items.hideDickbar) {
-			hideDickbar();
-		}
-		if (items.disableLazyImages) {
-			disableLazyLoading();
-		}
-	});
+chrome.storage.sync.get(null, function(items) {
+	if (items.hideDickbar) {
+		hideDickbar();
+	}
+	if (items.disableLazyImages) {
+		disableLazyLoading();
+	}
+});
 
-	observer.observe(document.body, config);
-}
+observer.observe(document.body, config);

--- a/manifest.json
+++ b/manifest.json
@@ -16,17 +16,17 @@
     "chrome_style": true
   },
   "icons": {
-    "128": "icon.png" 
+    "128": "icon.png"
   },
   "browser_action": {
     "default_icon": "icon.png"
   },
   "permissions": [
-    "storage", "https://*/*"
+    "storage"
   ],
   "content_scripts": [
     {
-      "matches": ["https://*/*"],
+      "matches": ["https://medium.com/*"],
       "js": ["content.js"]
     }
   ]


### PR DESCRIPTION
Hi!
This if statement 
```
if (document.querySelector('head meta[property="al:ios:app_name"][content="medium"]')) {
...
}
```
is no longer working, because they changed head meta tag to be `... content="Medium" ..` (note the uppercase `M`), so the content script won't fire at all.

I've changed required permissions, its not good practice to ask permissions to all pages anyway.

