### PR TITLE
Hide postMeterBar & do it with CSS instead of JS

### DIFF
--- a/content.js
+++ b/content.js
@@ -13,6 +13,13 @@ var makeReadable = function() {
 	if (getUpdatesBar) {
 		getUpdatesBar.style.display = 'none';
 	}
+
+	// Load remaining styles
+	// This check makes sure the extension works on Chrome and Firefox.
+	if (typeof browser === 'undefined') {
+		browser = chrome;
+	}
+	document.head.insertAdjacentHTML('beforeend', '<link rel="stylesheet" type="text/css" href="' + browser.runtime.getURL("medium.css") + '">');
 };
 
 var hideHighlightMenu = function() {

--- a/manifest.json
+++ b/manifest.json
@@ -29,5 +29,8 @@
       "matches": ["https://*/*"],
       "js": ["content.js"]
     }
+  ],
+  "web_accessible_resources": [
+	  "medium.css"
   ]
 }

--- a/medium.css
+++ b/medium.css
@@ -1,0 +1,3 @@
+.postMeterBar {
+	display: none;
+}

--- a/medium.css
+++ b/medium.css
@@ -1,3 +1,7 @@
+/**
+ * medium.css
+ * Contains default styles to inject into Medium publications.
+ */
 .postMeterBar {
 	display: none;
 }


### PR DESCRIPTION
This hides the `postMeterBar` (closing #19) and, since it wasn't possible with JS, includes the style with an injected stylesheet (closing #8).

We can now include default styles in `medium.css` instead of using JS all the time.