### PR TITLE
Attempt to hide all premium content

### DIFF
--- a/content.js
+++ b/content.js
@@ -15,7 +15,7 @@ var makeReadable = function() {
 	// don't want to obliterate them too.
 	// FIXME: prevent this from breaking signup/login dialogs when the popup
 	//   is removed (it works after changing pages).
-	var headings = document.evaluate("//h1[contains(., 'Pardon the interruption.')]", document, null, XPathResult.ANY_TYPE, null );
+	var headings = document.evaluate("//h1[contains(., 'Pardon the interruption.')]", document, null, XPathResult.ANY_TYPE, null);
 	var thisHeading = headings.iterateNext();
 	if (thisHeading != null) {
 		var $overlay = thisHeading.parentNode.parentNode.parentNode.parentNode;
@@ -54,7 +54,7 @@ var disableLazyLoading = function() {
 	if (hiddenMedia.length === 0) {
 		return;
 	}
-	for (var i=0; i<hiddenMedia.length; i++) {
+	for (var i = 0; i < hiddenMedia.length; i++) {
 		// Create new <img> element from the one in <noscript> and add it in.
 		// This is certainly a roundabout way of doing things, but I didn't want to
 		// spend more time reverse-engineering Medium's lazy-loading code.
@@ -80,6 +80,7 @@ var hidePremiumContent = function() {
 	var icon = "span.svgIcon.svgIcon--star";
 	document.querySelector('.js-homeStream') ? document.querySelector('.js-homeStream').remove() : null;
 	document.querySelectorAll(icon).forEach(function(iconElem) {
+		iconElem.closest('li.u-flex') ? iconElem.closest('li.u-flex').remove() : null;
 		iconElem.closest('div.streamItem') ? iconElem.closest('div.streamItem').remove() : null;
 		iconElem.closest('div.u-borderBox.js-sectionItem') ? iconElem.closest('div.u-borderBox.js-sectionItem').remove() : null;
 	});

--- a/content.js
+++ b/content.js
@@ -76,14 +76,6 @@ var shrinkHeaderImages = function() {
 	}
 }
 
-var observer = new MutationObserver(function(mutations){
-	mutations.forEach(function(){
-		makeReadable();
-		shrinkHeaderImages();
-	});	
-});
-
-var config = {attributes: true};
 var hidePremiumContent = function() {
 	var icon = "span.svgIcon.svgIcon--star";
 	document.querySelector('.js-homeStream') ? document.querySelector('.js-homeStream').remove() : null;
@@ -98,6 +90,8 @@ var hidePremiumContent = function() {
 if (document.querySelector('head meta[property="al:ios:app_name"][content="medium" i]')) {
 	makeReadable();
 	shrinkHeaderImages();
+	var hidePremiumContentFlag = false;
+	var config = {attributes: true};
 
 	chrome.storage.sync.get(null, function(items) {
 		if (items.hideDickbar) {
@@ -109,6 +103,20 @@ if (document.querySelector('head meta[property="al:ios:app_name"][content="mediu
 		if (items.hideHighlightMenu) {
 			hideHighlightMenu();
 		}
+		if (items.hidePremiumContent) {
+			hidePremiumContentFlag = true;
+			config.childList = true;
+		}
+	});
+
+	var observer = new MutationObserver(function(mutations) {
+		mutations.forEach(function() {
+			makeReadable();
+			shrinkHeaderImages();
+			if (hidePremiumContentFlag) {
+				hidePremiumContent();
+			}
+		});
 	});
 
 	observer.observe(document.body, config);

--- a/content.js
+++ b/content.js
@@ -84,6 +84,14 @@ var observer = new MutationObserver(function(mutations){
 });
 
 var config = {attributes: true};
+var hidePremiumContent = function() {
+	var icon = "span.svgIcon.svgIcon--star";
+	document.querySelector('.js-homeStream') ? document.querySelector('.js-homeStream').remove() : null;
+	document.querySelectorAll(icon).forEach(function(iconElem) {
+		iconElem.closest('div.streamItem') ? iconElem.closest('div.streamItem').remove() : null;
+		iconElem.closest('div.u-borderBox.js-sectionItem') ? iconElem.closest('div.u-borderBox.js-sectionItem').remove() : null;
+	});
+}
 
 // This extension runs on all domains so it can Make Medium Readable Again even for publications on custom domains.
 // Here we make sure the code only runs on Medium sites.

--- a/options.html
+++ b/options.html
@@ -32,6 +32,10 @@
 			<input type="checkbox" id="highlight"> Disable Highlight Menu
 		</label>
 
+		<label>
+			<input type="checkbox" id="premium"> Hide premium content
+		</label>	
+
 		<hr />
 
 		<h2>Default Features</h2>

--- a/options.js
+++ b/options.js
@@ -3,10 +3,12 @@ function save_options() {
   var hideDickbar = document.getElementById('dickbar').checked;
   var disableLazyImages = document.getElementById('images').checked;
   var hideHighlightMenu = document.getElementById('highlight').checked;
+  var hidePremiumContent = document.getElementById('premium').checked;
   chrome.storage.sync.set({
     hideDickbar: hideDickbar,
     disableLazyImages: disableLazyImages,
-    hideHighlightMenu: hideHighlightMenu
+    hideHighlightMenu: hideHighlightMenu,
+    hidePremiumContent: hidePremiumContent
   }, function() {
     // Update status to let user know options were saved.
     var status = document.getElementById('status');
@@ -23,11 +25,13 @@ function restore_options() {
   chrome.storage.sync.get({
     hideDickbar: false,
     disableLazyImages: false,
-    hideHighlightMenu: false
+    hideHighlightMenu: false,
+    hidePremiumContent: false
   }, function(items) {
     document.getElementById('dickbar').checked = items.hideDickbar;
     document.getElementById('images').checked = items.disableLazyImages;
     document.getElementById('highlight').checked = items.hideHighlightMenu;
+    document.getElementById('premium').checked = items.hidePremiumContent;
   });
 }
 document.addEventListener('DOMContentLoaded', restore_options);


### PR DESCRIPTION
This removes all elements on the page that have the little premium star inside them.
The only slight issue is with the Popular on Medium section where, by removing the premium articles, leaves the list with random elements (i.e. if there were 5 articles [1,2,3,4,5] after removing premium articles the list only has 2 elements [3,5]) and it might look bad. An alternative would be to remove the popular on medium entirely?
All inspiration for the code comes from [here](https://github.com/surajmandalcell/medium-free-firefox)