### PR TITLE
Added option for hiding gifs

### DIFF
--- a/content.js
+++ b/content.js
@@ -30,6 +30,27 @@ var makeReadable = function() {
 	document.head.insertAdjacentHTML('beforeend', '<link rel="stylesheet" type="text/css" href="' + browser.runtime.getURL("medium.css") + '">');
 };
 
+var hideGifs = function() {
+
+	// For all progressive media components, if it contains a giphy or gif thumbnail we'll want to hide it
+	var progressiveMediaElements = document.querySelectorAll('.progressiveMedia');
+
+	progressiveMediaElements.forEach(function(mediaElement) {
+		var childImages = mediaElement.querySelectorAll('img');
+		childImages.forEach(function(image) {
+			if (image.src && (image.src.indexOf('gif') !== -1 || image.src.indexOf('giphy') !== -1)) {
+
+				// Hide the media element
+				mediaElement.style.display = 'none';
+				mediaElement.style.height = 0;
+
+				// The media element's parent is a "aspectRatioPlaceholder".  We want to make its height 0 as well
+				mediaElement.parentElement.style.height = 0;
+			}
+		});
+	});
+}
+
 var hideHighlightMenu = function() {
 	var bar = document.querySelector('.highlightMenu');
 	if (bar) {
@@ -80,7 +101,7 @@ var observer = new MutationObserver(function(mutations){
 	mutations.forEach(function(){
 		makeReadable();
 		shrinkHeaderImages();
-	});	
+	});
 });
 
 var config = {attributes: true};
@@ -100,6 +121,9 @@ if (document.querySelector('head meta[property="al:ios:app_name"][content="mediu
 		}
 		if (items.hideHighlightMenu) {
 			hideHighlightMenu();
+		}
+		if (items.hideGifs) {
+			hideGifs();
 		}
 	});
 

--- a/options.html
+++ b/options.html
@@ -32,6 +32,10 @@
 			<input type="checkbox" id="highlight"> Disable Highlight Menu
 		</label>
 
+		<label>
+			<input type="checkbox" id="hidegifs"> Hide gifs
+		</label>
+
 		<hr />
 
 		<h2>Default Features</h2>

--- a/options.js
+++ b/options.js
@@ -3,10 +3,12 @@ function save_options() {
   var hideDickbar = document.getElementById('dickbar').checked;
   var disableLazyImages = document.getElementById('images').checked;
   var hideHighlightMenu = document.getElementById('highlight').checked;
+  var hideGifs = document.getElementById('hidegifs').checked;
   chrome.storage.sync.set({
     hideDickbar: hideDickbar,
     disableLazyImages: disableLazyImages,
-    hideHighlightMenu: hideHighlightMenu
+    hideHighlightMenu: hideHighlightMenu,
+    hideGifs: hideGifs
   }, function() {
     // Update status to let user know options were saved.
     var status = document.getElementById('status');
@@ -23,11 +25,13 @@ function restore_options() {
   chrome.storage.sync.get({
     hideDickbar: false,
     disableLazyImages: false,
-    hideHighlightMenu: false
+    hideHighlightMenu: false,
+    hideGifs: false
   }, function(items) {
     document.getElementById('dickbar').checked = items.hideDickbar;
     document.getElementById('images').checked = items.disableLazyImages;
     document.getElementById('highlight').checked = items.hideHighlightMenu;
+    document.getElementById('hidegifs').checked = items.hideGifs;
   });
 }
 document.addEventListener('DOMContentLoaded', restore_options);


### PR DESCRIPTION
Here's a rough cut for the first option in #13 .  

I found that Medium loads embedded gifs and Giphy links with an element with a `progressiveMedia` class, in which lives a preview thumbnail.  If this thumbnail is a gif or a link to giphy, this hides it.  This also hides the parent element, which is a `aspectRatioPlaceholder`.

I'd be interested in taking a look at the second implementation as well, but I figured I would start with this!

Before:
![screen shot 2018-07-17 at 5 57 08 pm](https://user-images.githubusercontent.com/17228751/42847712-e72e5a36-89ea-11e8-8ece-21c332fa1db8.png)


After `hideGifs()`:
![screen shot 2018-07-17 at 5 57 23 pm](https://user-images.githubusercontent.com/17228751/42847713-e73ccdc8-89ea-11e8-8abe-0081c2e1b0d0.png)
