### PR TITLE
Fix medium detection

### DIFF
--- a/MMRA.safariextension/content.js
+++ b/MMRA.safariextension/content.js
@@ -87,9 +87,9 @@ var config = {attributes: true};
 
 // This extension runs on all domains so it can Make Medium Readable Again even for publications on custom domains.
 // Here we make sure the code only runs on Medium sites.
-if (document.querySelector('head meta[property="al:ios:app_name"][content="medium" i]')) {
 	makeReadable();
 	shrinkHeaderImages();
+if (document.querySelector('head[prefix*="medium-com:"]')) {
 
 	chrome.storage.sync.get(null, function(items) {
 		if (items.hideDickbar) {

--- a/MMRA.safariextension/content.js
+++ b/MMRA.safariextension/content.js
@@ -87,9 +87,9 @@ var config = {attributes: true};
 
 // This extension runs on all domains so it can Make Medium Readable Again even for publications on custom domains.
 // Here we make sure the code only runs on Medium sites.
+if (document.querySelector('head[prefix*="medium-com:"]')) {
 	makeReadable();
 	shrinkHeaderImages();
-if (document.querySelector('head[prefix*="medium-com:"]')) {
 
 	chrome.storage.sync.get(null, function(items) {
 		if (items.hideDickbar) {

--- a/content.js
+++ b/content.js
@@ -87,9 +87,9 @@ var config = {attributes: true};
 
 // This extension runs on all domains so it can Make Medium Readable Again even for publications on custom domains.
 // Here we make sure the code only runs on Medium sites.
-if (document.querySelector('head meta[property="al:ios:app_name"][content="medium" i]')) {
 	makeReadable();
 	shrinkHeaderImages();
+if (document.querySelector('head[prefix*="medium-com:"]')) {
 
 	chrome.storage.sync.get(null, function(items) {
 		if (items.hideDickbar) {

--- a/content.js
+++ b/content.js
@@ -87,9 +87,9 @@ var config = {attributes: true};
 
 // This extension runs on all domains so it can Make Medium Readable Again even for publications on custom domains.
 // Here we make sure the code only runs on Medium sites.
+if (document.querySelector('head[prefix*="medium-com:"]')) {
 	makeReadable();
 	shrinkHeaderImages();
-if (document.querySelector('head[prefix*="medium-com:"]')) {
 
 	chrome.storage.sync.get(null, function(items) {
 		if (items.hideDickbar) {


### PR DESCRIPTION
The old detection doesn't work on custom domain websites since medium only populate meta tag after the extension loaded.

Fix #40 