### PR TITLE
Add browser badges with extension versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 <p align="center">
 	<img src="https://baer.works/image/MMRA-marquee.png" alt="Make Medium Readable Again" />
 </p>
+
 <p align="center">
 	<a href="https://chrome.google.com/webstore/detail/kljjfejkagofbgklifblndjelgabcmig"><img src="https://baer.works/image/CWS.png" alt="Available in the Chrome Web Store" /></a>
 	<a href="https://addons.mozilla.org/addon/make-medium-readable-again/"><img src="https://baer.works/image/AMO.png" alt="Get the Firefox Add-on" /></a>
 </p>
+
+<p align="center">
+    <a href="https://chrome.google.com/webstore/detail/kljjfejkagofbgklifblndjelgabcmig"><img src="https://img.shields.io/chrome-web-store/v/kljjfejkagofbgklifblndjelgabcmig.svg?logo=google%20chrome&label=Chrome" alt="Available in the Chrome Web Store" /></a>
+    <a href="https://addons.mozilla.org/addon/make-medium-readable-again"><img src="https://img.shields.io/amo/v/make-medium-readable-again.svg?logo=mozilla%20firefox&label=Firefox" alt="Get the Firefox Add-on" /></a>
+</p>
+
 <hr />
 
 Make Medium Readable Again is a [Chrome extension](https://chrome.google.com/webstore/detail/kljjfejkagofbgklifblndjelgabcmig), [Firefox add-on](https://addons.mozilla.org/addon/make-medium-readable-again/) and [Safari extension](https://safari-extensions.apple.com/details/?id=com.abunchtell.mmra-TPPAB4YBA6) that improves a reading experience ruined by user engagement tactics. Medium was actually readable once; this extension aims to help people pay attention to writers' words again instead of Medium's UX.


### PR DESCRIPTION
Display latest add-on versions for Firefox and Chrome information below banner. Shields badges do not yet support Safari extension versions. 

If you like this, What should we do with the extension link images just above this ? Both install images and badges link to same page, But both serve different purpose. 