### PR TITLE
Add option to remove "Top highlight" markers

### DIFF
--- a/content.js
+++ b/content.js
@@ -37,6 +37,43 @@ var hideHighlightMenu = function() {
 	document.head.insertAdjacentHTML('beforeend', '<style type="text/css">.highlightMenu { display: none; }</style>');
 };
 
+var isTopHighlightNode = function(node) {
+	return (
+		node.nodeType === Node.ELEMENT_NODE &&
+		node.classList.contains('markup--quote') &&
+		node.classList.contains('is-other')
+	);
+}
+
+var removeHighlight = function(node) {
+	node.classList.remove('markup--quote');
+	var parentNode = node.parentNode;
+	var name = parentNode.getAttribute('name');
+	if (name) {
+		var control = document.querySelector('.js-paragraphControl-' + name);
+		if (control) {
+			control.remove();
+		}
+	}
+}
+
+var hideTopHighlight = function() {
+	var highlightObserver = new MutationObserver(function(mutations) {
+		mutations.forEach(function(mutation) {
+			mutation.addedNodes.forEach(function(node) {
+				if (isTopHighlightNode(node)) {
+					removeHighlight(node);
+				}
+			});
+		});
+	});
+
+	highlightObserver.observe(document.body, {
+		childList: true,
+		subtree: true
+	});
+};
+
 var hideDickbar = function() {
 	var dickbar = document.querySelector('.js-postShareWidget');
 	if (dickbar) {
@@ -100,6 +137,9 @@ if (document.querySelector('head meta[property="al:ios:app_name"][content="mediu
 		}
 		if (items.hideHighlightMenu) {
 			hideHighlightMenu();
+		}
+		if (items.hideTopHighlight) {
+			hideTopHighlight();
 		}
 	});
 

--- a/options.html
+++ b/options.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<meta charset="utf-8">
 		<title>Make Medium Readable Again Settings</title>
 		<style>
 		body: { padding: 10px; }
@@ -29,7 +30,11 @@
 		</label>
 
 		<label>
-			<input type="checkbox" id="highlight"> Disable Highlight Menu
+			<input type="checkbox" id="highlight-menu"> Disable Highlight Menu
+		</label>
+
+		<label>
+			<input type="checkbox" id="top-highlight"> Disable “Top highlight” markers
 		</label>
 
 		<hr />

--- a/options.js
+++ b/options.js
@@ -2,11 +2,13 @@
 function save_options() {
   var hideDickbar = document.getElementById('dickbar').checked;
   var disableLazyImages = document.getElementById('images').checked;
-  var hideHighlightMenu = document.getElementById('highlight').checked;
+  var hideHighlightMenu = document.getElementById('highlight-menu').checked;
+  var hideTopHighlight = document.getElementById('top-highlight').checked;
   chrome.storage.sync.set({
     hideDickbar: hideDickbar,
     disableLazyImages: disableLazyImages,
-    hideHighlightMenu: hideHighlightMenu
+    hideHighlightMenu: hideHighlightMenu,
+    hideTopHighlight: hideTopHighlight
   }, function() {
     // Update status to let user know options were saved.
     var status = document.getElementById('status');
@@ -23,11 +25,13 @@ function restore_options() {
   chrome.storage.sync.get({
     hideDickbar: false,
     disableLazyImages: false,
-    hideHighlightMenu: false
+    hideHighlightMenu: false,
+    hideTopHighlight: false
   }, function(items) {
     document.getElementById('dickbar').checked = items.hideDickbar;
     document.getElementById('images').checked = items.disableLazyImages;
-    document.getElementById('highlight').checked = items.hideHighlightMenu;
+    document.getElementById('highlight-menu').checked = items.hideHighlightMenu;
+    document.getElementById('top-highlight').checked = items.hideTopHighlight;
   });
 }
 document.addEventListener('DOMContentLoaded', restore_options);


### PR DESCRIPTION
Closes #47.

I wasn't sure whether you're using `master` or `develop` as the primary branch. I've made this PR against `develop` purely because it had a few more commits on it.

This removes any "top highlight" indicators (background colour, "Top highlight" text in the sidebar), but leaves alone any personal highlights on your user account. I had to add it as another mutation observer, as the highlights are only added after the data has been retrieved from an async request.