### PR TITLE
Fix "pardon the interruption" popup block

### DIFF
--- a/content.js
+++ b/content.js
@@ -4,9 +4,9 @@
 
 var makeReadable = function() {
 	// Un-position:fixed the top nav bar
-	var topNav = document.querySelector('.metabar.u-fixed');
+	var topNav = document.querySelector('.branch-journeys-top');
 	if (topNav) {
-		topNav.classList.remove('u-fixed');
+		topNav.parentNode.style.position = 'absolute';
 	}
 
 	// Remove the "Pardon the interruption" popup.

--- a/content.js
+++ b/content.js
@@ -15,7 +15,7 @@ var makeReadable = function() {
 	// don't want to obliterate them too.
 	// FIXME: prevent this from breaking signup/login dialogs when the popup
 	//   is removed (it works after changing pages).
-	var headings = document.evaluate("//h1[contains(., 'Pardon the interruption.')]", document, null, XPathResult.ANY_TYPE, null );
+	var headings = document.evaluate("//h2[contains(., 'one more story in your member preview this month')]", document, null, XPathResult.ANY_TYPE, null );
 	var thisHeading = headings.iterateNext();
 	if (thisHeading != null) {
 		var $overlay = thisHeading.parentNode.parentNode.parentNode.parentNode;

--- a/content.js
+++ b/content.js
@@ -15,10 +15,10 @@ var makeReadable = function() {
 	// don't want to obliterate them too.
 	// FIXME: prevent this from breaking signup/login dialogs when the popup
 	//   is removed (it works after changing pages).
-	var headings = document.evaluate("//h2[contains(., 'one more story in your member preview this month')]", document, null, XPathResult.ANY_TYPE, null );
+	var headings = document.evaluate("//h4[contains(., 'one more story in your member preview this month')]", document, null, XPathResult.ANY_TYPE, null );
 	var thisHeading = headings.iterateNext();
 	if (thisHeading != null) {
-		var $overlay = thisHeading.parentNode.parentNode.parentNode.parentNode;
+		var $overlay = thisHeading.parentNode.parentNode.parentNode.parentNode.parentNode.parentNode;
 		$overlay.parentNode.removeChild($overlay);
 	}
 


### PR DESCRIPTION
We must no longer "pardon the interruption" -- now we can "extend our
stay" and so on. The \<h1> text in this popup changed, and there seems to
be a few titles that get displayed. So now we look to the \<h2> instead
for blocking the _readus interruptus_ popup.

This fixes #51.